### PR TITLE
修复了SDL2在Windows链接失败的问题；添加了缺失头文件

### DIFF
--- a/include/infra/processor.hpp
+++ b/include/infra/processor.hpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <source_location>
 #include <stop_token>
+#include <optional>
 
 #include "utility/logic-error-utility.hpp"
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -2,10 +2,11 @@ add_rules("mode.debug", "mode.release")
 
 add_requires("imgui v1.91.9",			{system=false, configs={sdl2=true, sdl2_renderer=true, wchar32=true}})
 add_requires("jsoncpp 1.9.6",			{system=false})
-add_requires("libsdl2 2.32.2",			{system=false, configs={shared=true, sdl2_image=false, sdl2_mixer=true, sdl2_ttf=false}})
+add_requires("libsdl2 2.32.2",			{system=false, configs={sdl2_image=false, sdl2_mixer=true, sdl2_ttf=false}})
 add_requires("ffmpeg 7.1",				{system=false, configs={shared=true, ffmpeg=false}})
 add_requires("boost 1.88.0",			{system=false, configs={cmake=false, fiber=true}})
 add_requires("nativefiledialog 1.1.6",	{system=false})
+add_requires("fftw 3.3.10",				{system=false})
 
 includes("third-party")
 
@@ -21,7 +22,8 @@ target("nodey_audio")
 		"jsoncpp", 
 		"ffmpeg", 
 		"boost", 
-		"nativefiledialog"
+		"nativefiledialog",
+		"fftw"
 	)
 	
 	add_files("src/**.cpp")


### PR DESCRIPTION
修复了windows版本下optional库会缺失的问题
解决了windows版本下SDL2库动态链接失败的问题